### PR TITLE
Rename annexed_probe to dockable_probe

### DIFF
--- a/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
@@ -259,8 +259,8 @@ stealthchop_threshold: 0
 enable_force_move: true
 
 
-# Annexed Probe
-[annexed_probe]
+# Dockable Probe
+[dockable_probe]
 # connected to Z- Endstop on S6
 pin: PA0
 x_offset: -25.0 # offset for microswitch x direction off nozzle

--- a/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
@@ -259,8 +259,8 @@ stealthchop_threshold: 0
 enable_force_move: true
 
 
-# Annexed Probe
-[annexed_probe]
+# Dockable Probe
+[dockable_probe]
 # connected to E1 (Y-Max Port) Endstop on SPIDER
 pin: PA2
 x_offset: -25.0 # offset for microswitch x direction off nozzle


### PR DESCRIPTION
Latest version of https://github.com/KevinOConnor/klipper/pull/4328 renames `annexed_probe` to `dockable_probe`, so we should update as well, in my opinion.