### PR TITLE
Update to latest version of dockable probe

### DIFF
--- a/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
@@ -259,8 +259,8 @@ stealthchop_threshold: 0
 enable_force_move: true
 
 
-# Annexed Probe
-[annexed_probe]
+# Dockable Probe
+[dockable_probe]
 # connected to Z- Endstop on S6
 pin: PA0
 x_offset: -25.0 # offset for microswitch x direction off nozzle
@@ -275,11 +275,10 @@ speed: 3
 lift_speed: 15
 
 # annexed probe specific
-dock_position:             -8,181, 20 #back left corner of gantry
+dock_position:             -8,181,20 #back left corner of gantry
+approach_position:         32,181,20
+detach_position:           -8,141,20
 safe_z_position:           90,90 #center of bed
-dock_angle:                0
-detach_angle:              270
-dock_safe_distance:        40
 attach_speed:              20
 detach_speed:              100
 travel_speed:              300

--- a/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
@@ -259,8 +259,8 @@ stealthchop_threshold: 0
 enable_force_move: true
 
 
-# Annexed Probe
-[annexed_probe]
+# Dockable Probe
+[dockable_probe]
 # connected to E1 (Y-Max Port) Endstop on SPIDER
 pin: PA2
 x_offset: -25.0 # offset for microswitch x direction off nozzle
@@ -275,11 +275,10 @@ speed: 3
 lift_speed: 15
 
 # annexed probe specific
-dock_position:             -8,181, 20 #back left corner of gantry
+dock_position:             -8,181,20 #back left corner of gantry
+approach_position:         32,181,20
+detach_position:           -8,141,20
 safe_z_position:           90,90 #center of bed
-dock_angle:                0
-detach_angle:              270
-dock_safe_distance:        40
 attach_speed:              20
 detach_speed:              100
 travel_speed:              300


### PR DESCRIPTION
The latest version of https://github.com/KevinOConnor/klipper/pull/4328/ renames this Klipper module from `annexed_probe` to `dockable_probe` and makes a few configuration changes.  Instead of specifying `dock_angle`, `detach_angle` and `dock_safe_distance`, you now specify an `approach_position` and `detach_position`.

The `approach_position` is where the toolhead will move prior making the final move into the `dock_position` location.  Similarly, when docking the toolhead will move to `detach_position` after the probe is in the dock.