### PR TITLE
Add note to configs about tuning sensorless homing

### DIFF
--- a/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
@@ -197,6 +197,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PB14 #connected to X- Endstop (X Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
 
 [tmc2209 stepper_x1]
@@ -208,6 +209,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PB13 #connected to Y- Endstop (Y Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
 
 [tmc2209 stepper_y]
@@ -219,6 +221,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PA3 #connected to Z+ Endstop (E0 Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
 
 [tmc2209 stepper_y1]
@@ -230,6 +233,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PA2 #connected to Y+ Endstop (E1 Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
  
 [tmc2209 stepper_z]

--- a/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
@@ -197,6 +197,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PB14 #connected to X Endstop (X Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
 
 [tmc2209 stepper_x1]
@@ -208,6 +209,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PB13 #connected to Y Endstop (Y Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
 
 [tmc2209 stepper_y]
@@ -219,6 +221,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PA0 #connected to Z Endstop (Z Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
 
 [tmc2209 stepper_y1]
@@ -230,6 +233,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 0
 # Place a jumper on the two pin header near the endstop for sensorless homing
 diag_pin: PA3 #connected to E0 Endstop (E0 Jumper Header)
+# You may need to tune this value.  See https://www.klipper3d.org/TMC_Drivers.html#sensorless-homing
 driver_SGTHRS: 115
  
 [tmc2209 stepper_z]


### PR DESCRIPTION
I doubt all printers will have the same SGTHRS value for senseless homing.  This change adds a comment to each occurrence of this setting in the config files, directing you to Klipper's TMC sensorless homing docs.