### PR TITLE
Improvements to XY Gantry README

### DIFF
--- a/STLs/XY_Gantry/README.md
+++ b/STLs/XY_Gantry/README.md
@@ -1,0 +1,21 @@
+XY Gantry Options
+=================
+
+## Motor Mounts
+
+**M6 Corner Screw**
+This option accomodates 2020 vertical extrusions that are tapped as M6 instead of M5.
+
+**Custom LDO Motor**
+Use this option if you are using the custom long shaft motors from LDO.
+
+## Linear Rail Instructions
+
+**Running Robotdigg Rails**?
+If you are using robotdigg rails, you should to use the STLs in the `for_6.0mm_thick_rails` folder for the tensioner spacer and rail mounts, as these rails are 0.5mm thinner.
+
+**General Sizing Tips**
+- Before printing the tensioner spacer, try slicing the main toolhead plate (with whatever settings you will/did use to print it) and check the distance from the bottom to the surface that sits underneath the upside-down rail.
+- Try slicing the tensioner spacer, and make sure its sliced height from top to bottom is 14.0mm more than your measurement from the toolhead plate.
+    - For example, if the thickness on the toolhead plate ends up being 6.6mm, then your tensioner spacer should end up being 20.6mm tall.
+- Scale the tensioner spacer (in the z axis only) if it is the wrong size when sliced.

--- a/STLs/XY_Gantry/for_6.0mm_thick_rails/README.md
+++ b/STLs/XY_Gantry/for_6.0mm_thick_rails/README.md
@@ -1,5 +1,0 @@
-If you are using robotdigg rails, you will have to use these modified stls for the tensioner spacer and rail mounts since the rails are 0.5mm thinner.
-- Before printing the tensioner spacer, try slicing the main toolhead plate (with whatever settings you will/did use to print it) and check the distance from the bottom to the surface that sits underneath the upside-down rail.
-- Try slicing the tensioner spacer, and make sure its sliced height from top to bottom is 14.0mm more than your measurement from the toolhead plate.
-    - For example, if the thickness on the toolhead plate ends up being 6.6mm, then your tensioner spacer should end up being 20.6mm tall.
-- Scale the tensioner spacer (in the z axis only) if it is the wrong size when sliced.


### PR DESCRIPTION
Moves the README about linear rail options one level down to the `XY_Gantry` folder.  I was trying to remember if I needed the 6.0mm or 6.5mm spacers, and didn't realize there was a README in the `for_6.0mm_thick_rails` folder and wound up searching Discord for a bit.  This should make those instructions a bit more noticeable.

I also added some notes about the motor mount options.