### PR TITLE
Minor changes to multiple settings

### DIFF
--- a/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
@@ -84,7 +84,7 @@ resolution: 0.1
 [stepper_x]
 # connected to X Stepper on SPIDER
 step_pin: PE11
-dir_pin: PE10
+dir_pin: !PE10
 enable_pin: !PE9
 # 20t Pulley, 2mm Pitch on a 0.9deg Motor
 rotation_distance: 40
@@ -96,12 +96,13 @@ position_min: -8
 position_endstop: 180
 position_max: 180
 homing_speed: 50.0
+homing_retract_dist: 0
 homing_positive_dir: true
 
 [stepper_x1]
 # connected to Y Stepper on SPIDER
 step_pin: PD8
-dir_pin: !PB12
+dir_pin: PB12
 enable_pin: !PD9
 # 20t Pulley, 2mm Pitch on a 0.9deg Motor
 rotation_distance: 40
@@ -127,6 +128,7 @@ position_min: -2
 position_endstop: -2
 position_max: 184
 homing_speed: 50.0
+homing_retract_dist: 0
 homing_positive_dir: false
 
 [stepper_y1]
@@ -158,7 +160,7 @@ full_steps_per_rotation: 200
 endstop_pin: probe:z_virtual_endstop
 position_max: 170 #this is set here on purpose, your actual travel will vary based on spring compression holding the bed, adjust at your own risk
 position_min: -5
-homing_speed: 15.0
+homing_speed: 10.0
 second_homing_speed: 5.0
 homing_retract_dist: 10.0
 homing_positive_dir: false
@@ -278,7 +280,7 @@ enable_force_move: true
 # Dockable Probe
 [dockable_probe]
 # connected to E1 (Y-Max Port) Endstop on SPIDER
-pin: PA2
+pin: ^PA2
 x_offset: -25.0 # offset for microswitch x direction off nozzle
 y_offset: -1.88 # offset for microswitch y direction off nozzle
 z_offset: 2 # offset for microswitch in z height - this is a starting point only
@@ -288,7 +290,7 @@ samples_result: median
 samples_tolerance: 0.02
 samples_tolerance_retries: 3
 speed: 3
-lift_speed: 15
+lift_speed: 10
 
 # annexed probe specific
 dock_position:             -8,181,20 #back left corner of gantry
@@ -362,7 +364,7 @@ sensor_pin: PC1
 smooth_time: 3.0
 
 #Build Plate PID Settings
-max_power: 0.60
+max_power: 0.4
 control: pid
 pid_Kp: 42.475 
 pid_Ki: 1.395 
@@ -372,7 +374,8 @@ max_temp: 110
 
 #Raspberry Pi Temperature Sensor
 [temperature_sensor pi_cpu]
-sensor_type: rpi_temperature
+sensor_type: temperature_host
+sensor_path: "/sys/class/thermal/thermal_zone0/temp"
 gcode_id: P
 
  

--- a/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
@@ -64,7 +64,7 @@ path: ~/gcode_files
 kinematics: cartesian
 max_velocity: 500
 max_accel: 2000 #change this to 7500 after commissioning
-max_z_velocity: 10
+max_z_velocity: 10   #may be able to increase to 15 after comissioning.
 max_z_accel: 100
 square_corner_velocity: 8.0
 
@@ -160,7 +160,7 @@ full_steps_per_rotation: 200
 endstop_pin: probe:z_virtual_endstop
 position_max: 170 #this is set here on purpose, your actual travel will vary based on spring compression holding the bed, adjust at your own risk
 position_min: -5
-homing_speed: 10.0
+homing_speed: 15.0
 second_homing_speed: 5.0
 homing_retract_dist: 10.0
 homing_positive_dir: false
@@ -290,7 +290,7 @@ samples_result: median
 samples_tolerance: 0.02
 samples_tolerance_retries: 3
 speed: 3
-lift_speed: 10
+lift_speed: 15
 
 # annexed probe specific
 dock_position:             -8,181,20 #back left corner of gantry


### PR DESCRIPTION
Reversed directions of X and X1 steppers
Added "homing_retract_dist: 0" for X and Y steppers
Reduced z homing speed and probe lift speed to match z max_speed
Added pullup to probe pin
Reduced heater power from 0.6 to 0.4 to better match recommended 0.4W/cm^2
Updated RPi temp block from depreciated format