### PR TITLE
Update example configs w/10t & 8t gear ratios for Sherpa Mini

### DIFF
--- a/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_s6_2.0_+_btt_motor_expander_config-180mm_x_180mm_x_180mm_build.cfg
@@ -333,7 +333,7 @@ step_pin: PD14
 dir_pin: !PD13
 enable_pin: !PD15
 rotation_distance: 22.67895 #for 5mm Shaft Driven Bondtech gearsets
-gear_ratio: 5:1 #Sherpa Mini uses 5:1, Folded Ascender Use 40:1 or 20:1
+gear_ratio: 5:1 #Sherpa Mini 10t uses 5:1 or 8t uses 50:8, Folded Ascender Use 40:1 or 20:1
 microsteps: 16
 full_steps_per_rotation: 200 #1.8 deg motor
 

--- a/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
+++ b/Klipper_Config/K3_fysetc_spider_config-180mm_x_180mm_x_180mm_build.cfg
@@ -335,7 +335,7 @@ step_pin: PE1
 dir_pin: !PE0
 enable_pin: !PC5
 rotation_distance: 22.67895 #for 5mm Shaft Driven Bondtech gearsets
-gear_ratio: 5:1 #Sherpa Mini uses 5:1, Folded Ascender Use 40:1 or 20:1
+gear_ratio: 5:1 #Sherpa Mini 10t uses 5:1 or 8t uses 50:8, Folded Ascender Use 40:1 or 20:1
 microsteps: 16
 full_steps_per_rotation: 200 #1.8 deg motor
 


### PR DESCRIPTION
These comment tweaks provide users with correct gearing ratios for either variant of the Sherpa Mini motor.  The 8t was not included before.